### PR TITLE
Get next trace id from data instead of trace

### DIFF
--- a/src/frontend/classify.js
+++ b/src/frontend/classify.js
@@ -41,8 +41,7 @@ function showNextTrace() {
   var url = 'http://127.0.0.1:8337/trace/unknown/' + traceId + '/next';
 
   request.get({uri: url, json: true}, function(err, pkg, data) {
-    trace = data.trace;
-    showTrace(trace.id);
+    showTrace(data.id);
   });
 }
 


### PR DESCRIPTION
`data` doesn't have a `trace`, therefore it couldn't find the `id`.  
